### PR TITLE
optionally ignore extra fields when deserializing

### DIFF
--- a/src/rospy_message_converter/json_message_converter.py
+++ b/src/rospy_message_converter/json_message_converter.py
@@ -1,18 +1,20 @@
 import json
 from rospy_message_converter import message_converter
 
-def convert_json_to_ros_message(message_type, json_message):
+def convert_json_to_ros_message(message_type, json_message, strict_mode=True):
     """
     Takes in the message type and a JSON-formatted string and returns a ROS
     message.
 
+    If strict_mode is set, an exception will be thrown if the json message contains extra fields
+    
     Example:
         message_type = "std_msgs/String"
         json_message = '{"data": "Hello, Robot"}'
         ros_message = convert_json_to_ros_message(message_type, json_message)
     """
     dictionary = json.loads(json_message)
-    return message_converter.convert_dictionary_to_ros_message(message_type, dictionary)
+    return message_converter.convert_dictionary_to_ros_message(message_type, dictionary, strict_mode=strict_mode)
 
 def convert_ros_message_to_json(message):
     """

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -62,7 +62,7 @@ ros_binary_types_regexp = re.compile(r'(uint8|char)\[[^\]]*\]')
 
 list_brackets = re.compile(r'\[[^\]]*\]')
 
-def convert_dictionary_to_ros_message(message_type, dictionary, kind='message'):
+def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', strict_mode=True):
     """
     Takes in the message type and a Python dictionary and returns a ROS message.
 
@@ -97,7 +97,10 @@ def convert_dictionary_to_ros_message(message_type, dictionary, kind='message'):
         else:
             error_message = 'ROS message type "{0}" has no field named "{1}"'\
                 .format(message_type, field_name)
-            raise ValueError(error_message)
+            if strict_mode:
+                raise ValueError(error_message)
+            else:
+                rospy.logerr('{}! It will be ignored.'.format(error_message))
 
     return message
 

--- a/test/test_message_converter.py
+++ b/test/test_message_converter.py
@@ -286,6 +286,21 @@ class TestMessageConverter(unittest.TestCase):
         expected_message = serialize_deserialize(expected_message)
         self.assertEqual(message, expected_message)
 
+    def test_dictionary_with_empty_additional_args_strict_mode(self):
+        from std_msgs.msg import Empty
+        dictionary = {"additional_args": "should raise value error"}
+        with self.assertRaises(ValueError) as context:
+            message_converter.convert_dictionary_to_ros_message('std_msgs/Empty', dictionary)
+        self.assertTrue("has no field named" in context.exception.message)
+
+    def test_dictionary_with_empty_additional_args_forgiving(self):
+        from std_msgs.msg import Empty
+        expected_message = Empty()
+        dictionary = {"additional_args": "should be ignored"}
+        message = message_converter.convert_dictionary_to_ros_message('std_msgs/Empty', dictionary, strict_mode=False)
+        expected_message = serialize_deserialize(expected_message)
+        self.assertEqual(message, expected_message)
+
     def test_dictionary_with_float32(self):
         from std_msgs.msg import Float32
         expected_message = Float32(data = struct.unpack('<f', '\x7F\x7F\xFF\xFD')[0])


### PR DESCRIPTION
closed one PR, opened another.

We often ran into troubles that we used the message converter to connect two systems with different "capabilities". If one non-ros System send a message which contained additional fields compared to "our" definition of the ros message, the message converter raises a ValueError. With the additional option `strict_mode` for converting json or dictionaries to ros messages extra fields can just be ignored.

Default behavior stays as before. The new feature needs to be explicitly enabled