### PR TITLE
Missing field wrong type

### DIFF
--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -118,6 +118,8 @@ def _convert_to_ros_type(field_type, field_value):
     elif field_type in ros_time_types:
         field_value = _convert_to_ros_time(field_type, field_value)
     elif field_type in ros_primitive_types:
+        if type(field_value).__name__ not in _extract_python_type(field_type):
+            raise TypeError("Wrong type: '{0}' must be {1}".format(field_value, field_type))
         field_value = _convert_to_ros_primitive(field_type, field_value)
     elif _is_field_type_a_primitive_array(field_type):
         field_value = field_value
@@ -195,6 +197,17 @@ def _convert_from_ros_type(field_type, field_value):
 
     return field_value
 
+def _extract_python_type(ros_type):
+    """
+    Find Python type from ROS type.
+    """
+    types = []
+    for k in python_to_ros_type_map:
+        if ros_type in python_to_ros_type_map[k]:
+            types.append(k)
+    if types == []:
+        raise TypeError("Cannot find {0} in python_to_ros_type_map".format(ros_type))
+    return types
 
 def is_ros_binary_type(field_type, field_value):
     """ Checks if the field is a binary array one, fixed size or not

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -63,7 +63,7 @@ ros_binary_types_regexp = re.compile(r'(uint8|char)\[[^\]]*\]')
 
 list_brackets = re.compile(r'\[[^\]]*\]')
 
-def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', strict_mode=True):
+def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', strict_mode=True, check_missing_fields=False):
     """
     Takes in the message type and a Python dictionary and returns a ROS message.
 
@@ -106,7 +106,7 @@ def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', 
             else:
                 rospy.logerr('{}! It will be ignored.'.format(error_message))
 
-    if remaining_message_fields:
+    if check_missing_fields and remaining_message_fields:
         error_message = 'Missing fields "{0}"'.format(remaining_message_fields)
         raise ValueError(error_message)
 

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -48,6 +48,23 @@ python_to_ros_type_map = {
     'unicode' : ['string'],
     'long'    : ['uint64']
 }
+ros_to_python_type_map = {
+    'bool'    : ['bool'],
+    'byte'    : ['int'],
+    'char'    : ['int'],
+    'float32' : ['int', 'float'],
+    'float64' : ['int', 'float'],
+    'int16'   : ['int'],
+    'int32'   : ['int'],
+    'int64'   : ['int'],
+    'int8'    : ['int'],
+    'string'  : ['str', 'unicode'],
+    'uint16'  : ['int'],
+    'uint32'  : ['int'],
+    'uint64'  : ['int', 'long'],
+    'uint8'   : ['int']
+}
+
 if python3:
     python_string_types = [str]
 else:
@@ -118,7 +135,7 @@ def _convert_to_ros_type(field_type, field_value):
     elif field_type in ros_time_types:
         field_value = _convert_to_ros_time(field_type, field_value)
     elif field_type in ros_primitive_types:
-        if type(field_value).__name__ not in _extract_python_type(field_type):
+        if type(field_value).__name__ not in ros_to_python_type_map[field_type]:
             raise TypeError("Wrong type: '{0}' must be {1}".format(field_value, field_type))
         field_value = _convert_to_ros_primitive(field_type, field_value)
     elif _is_field_type_a_primitive_array(field_type):
@@ -196,18 +213,6 @@ def _convert_from_ros_type(field_type, field_value):
         field_value = convert_ros_message_to_dictionary(field_value)
 
     return field_value
-
-def _extract_python_type(ros_type):
-    """
-    Find Python type from ROS type.
-    """
-    types = []
-    for k in python_to_ros_type_map:
-        if ros_type in python_to_ros_type_map[k]:
-            types.append(k)
-    if types == []:
-        raise TypeError("Cannot find {0} in python_to_ros_type_map".format(ros_type))
-    return types
 
 def is_ros_binary_type(field_type, field_value):
     """ Checks if the field is a binary array one, fixed size or not

--- a/test/test_message_converter.py
+++ b/test/test_message_converter.py
@@ -293,7 +293,8 @@ class TestMessageConverter(unittest.TestCase):
         dictionary = {"additional_args": "should raise value error"}
         with self.assertRaises(ValueError) as context:
             message_converter.convert_dictionary_to_ros_message('std_msgs/Empty', dictionary)
-            self.assertTrue("has no field named" in context.exception.message)
+        self.assertEqual('''ROS message type "std_msgs/Empty" has no field named "additional_args"''',
+                         context.exception.args[0])
 
     def test_dictionary_with_empty_additional_args_forgiving(self):
         from std_msgs.msg import Empty

--- a/test/test_message_converter.py
+++ b/test/test_message_converter.py
@@ -303,6 +303,27 @@ class TestMessageConverter(unittest.TestCase):
         expected_message = serialize_deserialize(expected_message)
         self.assertEqual(message, expected_message)
 
+    def test_dictionary_with_missing_field_unchecked(self):
+        from std_msgs.msg import Bool
+        expected_message = Bool(data=False)
+        dictionary = {}
+        message = message_converter.convert_dictionary_to_ros_message('std_msgs/Bool', dictionary)
+        expected_message = serialize_deserialize(expected_message)
+        self.assertEqual(message, expected_message)
+
+    def test_dictionary_with_missing_field_checked(self):
+        dictionary = {}
+        with self.assertRaises(ValueError) as context:
+            message_converter.convert_dictionary_to_ros_message('std_msgs/Bool', dictionary, check_missing_fields=True)
+        self.assertEqual('''Missing fields "{'data': 'bool'}"''',
+                         context.exception.args[0])
+
+    def test_dictionary_with_wrong_type(self):
+        dictionary = {"data": "should_be_a_bool"}
+        with self.assertRaises(TypeError) as context:
+            message_converter.convert_dictionary_to_ros_message('std_msgs/Bool', dictionary)
+        self.assertEqual("Wrong type: 'should_be_a_bool' must be bool", context.exception.args[0])
+
     def test_dictionary_with_float32(self):
         from std_msgs.msg import Float32
         expected_message = Float32(data = struct.unpack('<f', b'\x7F\x7F\xFF\xFD')[0])


### PR DESCRIPTION
For [issue #36](https://github.com/uos/rospy_message_converter/issues/36):

1. missing field are handled by a deepcopy of the dictionary `message_fields`, every field found are deleted and if anyone are in remaining dict a `ValueError` will be raised;
2. the wrong type are found by checking if the current type is one that are in the list of `python_to_ros_type_map[type]`, if not a `ValueError` will be raised;