### PR TITLE
python 3 fix for _convert_to_ros_binary

### DIFF
--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -150,9 +150,10 @@ def _convert_to_ros_type(field_type, field_value):
 def _convert_to_ros_binary(field_type, field_value):
     if type(field_value) in python_string_types:
         binary_value_as_string = base64.standard_b64decode(field_value)
+    elif python3:
+        binary_value_as_string = bytes(bytearray(field_value))
     else:
         binary_value_as_string = str(bytearray(field_value))
-
     return binary_value_as_string
 
 def _convert_to_ros_time(field_type, field_value):

--- a/test/test_message_converter.py
+++ b/test/test_message_converter.py
@@ -242,6 +242,14 @@ class TestMessageConverter(unittest.TestCase):
         expected_message = serialize_deserialize(expected_message)
         self.assertEqual(message, expected_message)
 
+    def test_dictionary_with_uint8_array(self):
+        from rospy_message_converter.msg import Uint8ArrayTestMessage
+        expected_message = Uint8ArrayTestMessage(data=[1, 2, 3, 4])
+        dictionary = {'data': expected_message.data}
+        message = message_converter.convert_dictionary_to_ros_message('rospy_message_converter/Uint8ArrayTestMessage', dictionary)
+        expected_message = serialize_deserialize(expected_message)
+        self.assertEqual(message, expected_message)
+
     def test_dictionary_with_bool(self):
         from std_msgs.msg import Bool
         expected_message = Bool(data = True)


### PR DESCRIPTION
In python3 you get:
In [1]: str(bytearray([1,2,3]))                                                                                                        
Out[1]: "bytearray(b'\\x01\\x02\\x03')"

Which is not what one wants in this function. Instead:
In [2]: bytes(bytearray([1,2,3]))                                                                                                      
Out[2]: b'\x01\x02\x03'

looks compatible to to the function result with python2.

this breaks reading a sensor_msgs/Image message from a dict for me. But I a still trying to figure out why it is not breaking the test_message_converter.py - test_ros_message_with_uint8_array should catch it.