### PR TITLE
added numpy as run_depend to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
 
+  <run_depend>python3-numpy</run_depend>
+
   <test_depend>rosunit</test_depend>
   <test_depend>std_srvs</test_depend>
 </package>


### PR DESCRIPTION
Since we build minimal sized images for our system we noticed that this package does not declare numpy as a dependency but uses it.