### PR TITLE
Convert data with null(json) or None(dictionary) value correctly to ros message

### DIFF
--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -213,7 +213,7 @@ def _convert_to_ros_time(field_type, field_value):
 
 def _convert_to_ros_primitive(field_type, field_value):
     # std_msgs/msg/_String.py always calls encode() on python3, so don't do it here
-    if field_type == "string" and not python3:
+    if field_type == "string" and not python3 and (field_value is not None):
         field_value = field_value.encode('utf-8')
     return field_value
 

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -156,7 +156,6 @@ def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', 
 
 def _convert_to_ros_type(field_name, field_type, field_value, strict_mode=True, check_missing_fields=False,
                          check_types=True):
-    print(field_type,field_value)
     if _is_ros_binary_type(field_type):
         if field_value is None:
             field_value = 0

--- a/src/rospy_message_converter/message_converter.py
+++ b/src/rospy_message_converter/message_converter.py
@@ -156,21 +156,37 @@ def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', 
 
 def _convert_to_ros_type(field_name, field_type, field_value, strict_mode=True, check_missing_fields=False,
                          check_types=True):
+    print(field_type,field_value)
     if _is_ros_binary_type(field_type):
+        if field_value is None:
+            field_value = 0
         field_value = _convert_to_ros_binary(field_type, field_value)
     elif field_type in ros_time_types:
+        if field_value is None:
+            field_value = {'secs':0,'nsecs':0}
         field_value = _convert_to_ros_time(field_type, field_value)
     elif field_type in ros_primitive_types:
         # Note: one could also use genpy.message.check_type() here, but:
         # 1. check_type is "not designed to run fast and is meant only for error diagnosis"
         # 2. it doesn't check floats (see ros/genpy#130)
         # 3. it rejects numpy types, although they can be serialized
+        if field_value is None:
+            if field_type=='string':
+                field_value = ''
+            elif field_type=='bool':
+                field_value = False
+            else:
+                field_value = 0
         if check_types and type(field_value) not in ros_to_python_type_map[field_type]:
             raise TypeError("Field '{0}' has wrong type {1} (valid types: {2})".format(field_name, type(field_value), ros_to_python_type_map[field_type]))
         field_value = _convert_to_ros_primitive(field_type, field_value)
     elif _is_field_type_a_primitive_array(field_type):
+        if field_value is None:
+            field_value = []
         field_value = field_value
     elif _is_field_type_an_array(field_type):
+        if field_value is None:
+            field_value = []
         field_value = _convert_to_ros_array(field_name, field_type, field_value, strict_mode, check_missing_fields,
                                             check_types)
     else:


### PR DESCRIPTION
It is quite common in my case that some ros message field are represented as 'null' by default.
when I call` convert_dictionary_to_ros_message()` with  `strict_mode = False, check_types = False`,  error "AttributeError: 'NoneType' object has no attribute 'encode' will be raised. 
Here's a simple fix