### PR TITLE
Update flake8 to 7.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,6 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8.git
-    rev: 5.0.4
+    rev: 7.0.0
     hooks:
     - id: flake8


### PR DESCRIPTION
This fixes the following wrong error messages:

    rclpy_message_converter/test/test_json_message_converter.py:84:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:85:20: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:86:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:87:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:89:61: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:90:61: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:92:24: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:93:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:94:58: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:95:58: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:96:58: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:98:24: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:99:20: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:100:16: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:102:-2: E202 whitespace before ']'
    rclpy_message_converter/test/test_json_message_converter.py:102:8: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:185:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:186:20: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:187:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:188:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:190:61: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:191:61: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:193:24: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:194:-1: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:195:58: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:196:58: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:197:58: E231 missing whitespace after ','
    rclpy_message_converter/test/test_json_message_converter.py:199:24: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:200:20: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:201:16: E202 whitespace before '}'
    rclpy_message_converter/test/test_json_message_converter.py:203:-2: E202 whitespace before ']'
    rclpy_message_converter/test/test_json_message_converter.py:203:8: E202 whitespace before '}'

This only happened in ROS2 rolling (python 3.12), not in Humble or Iron (python 3.10), both with flake8 3.7.9, 5.0.4 and 6.0.0. These are false alarms (flake8 doesn't recognize that these are multi-line json strings, not python source code).